### PR TITLE
👷 CI changes & 3rd party licence checks & Python 3.8

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,6 +80,12 @@ Run static analysis (note that no output means all is well):
 flake8
 ```
 
+Perform static type check:
+
+```bash
+mypy -p snippet
+```
+
 ## Documenting code
 
 Inclusion of docstrings is needed in all areas of the code for Flake8 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Snippet
 
-![Package](https://img.shields.io/badge/Package-code--snippet-lightgrey)
-[![Documentation](https://img.shields.io/badge/Documentation-GitHub_Pages-blue)](https://armmbed.github.io/snippet)
-[![PyPI](https://img.shields.io/pypi/v/code-snippet)](https://pypi.org/project/code-snippet/)
-[![PyPI - Status](https://img.shields.io/pypi/status/code-snippet)](https://pypi.org/project/code-snippet/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/code-snippet)](https://pypi.org/project/code-snippet/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ARMmbed/code-snippet/blob/master/LICENSE)
+![Package](https://badgen.net/badge/Package/code-snippet/grey) 
+[![Documentation](https://badgen.net/badge/Documentation/GitHub%20Pages/blue?icon=github)](https://armmbed.github.io/snippet) 
+[![PyPI](https://badgen.net/pypi/v/code-snippet)](https://pypi.org/project/code-snippet/) 
+[![PyPI - Status](https://img.shields.io/pypi/status/code-snippet)](https://pypi.org/project/code-snippet/) 
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/code-snippet)](https://pypi.org/project/code-snippet/) 
+ 
+[![License](https://badgen.net/pypi/license/code-snippet)](https://github.com/ARMmbed/snippet/blob/master/LICENSE) 
+[![Compliance](https://badgen.net/badge/License%20Report/compliant/green?icon=libraries)](https://armmbed.github.io/snippet/third_party_IP_report.html) 
 
 [![Build Status](https://dev.azure.com/mbed-tools/code-snippet/_apis/build/status/Build%20and%20Release?branchName=master&stageName=CI%20Checkpoint)](https://dev.azure.com/mbed-tools/code-snippet/_build/latest?definitionId=15&branchName=master)
 [![Test Coverage](https://codecov.io/gh/ARMmbed/code-snippet/branch/master/graph/badge.svg)](https://codecov.io/gh/ARMmbed/snippet)

--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -34,6 +34,11 @@ stages:
             Linux_Py_3_7:
               python.version: '3.7'
               vmImageName: ubuntu-latest
+              uploadCoverage: "false"
+
+            Linux_Py_3_8:
+              python.version: '3.8'
+              vmImageName: ubuntu-latest
               uploadCoverage: "true"
 
             Windows_Py_3_6:
@@ -46,6 +51,11 @@ stages:
               vmImageName: windows-latest
               uploadCoverage: "false"
 
+            Windows_Py_3_8:
+              python.version: '3.8'
+              vmImageName: windows-latest
+              uploadCoverage: "false"
+
             macOS_Py_3_6:
               python.version: '3.6'
               vmImageName: macOS-latest
@@ -55,6 +65,12 @@ stages:
               python.version: '3.7'
               vmImageName: macOS-latest
               uploadCoverage: "false"
+
+            macOS_Py_3_8:
+              python.version: '3.8'
+              vmImageName: macOS-latest
+              uploadCoverage: "false"
+
         pool:
           vmImage: $(vmImageName)
 
@@ -149,10 +165,6 @@ stages:
           - template: steps/install-development-dependencies.yml
 
           - template: steps/generate-spdx-documents.yml
-
-          - publish: $(temp_spdx_reports_path)
-            artifact: SPDX
-            displayName: 'Publish SPDX reports'
 
   # Collect test and build stages together before the release stages to provide a pass/fail point for the status badge.
   - stage: CiCheckpoint

--- a/azure-pipelines/steps/generate-spdx-documents.yml
+++ b/azure-pipelines/steps/generate-spdx-documents.yml
@@ -11,3 +11,8 @@ steps:
   - script: |
       license-files
     displayName: 'Add copyright/licence notice.'
+
+  - publish: $(temp_spdx_reports_path)
+    artifact: SPDX
+    displayName: 'Publish SPDX reports'
+    condition: always()

--- a/news/20200428.bugfix
+++ b/news/20200428.bugfix
@@ -1,0 +1,1 @@
+Checked 3rd-party licences.

--- a/news/20200428.misc
+++ b/news/20200428.misc
@@ -1,0 +1,1 @@
+Reset project's structure with latest template.

--- a/news/2020042801.bugfix
+++ b/news/2020042801.bugfix
@@ -1,0 +1,1 @@
+Tested on Python 3.8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ DOCUMENTATION_PRODUCTION_OUTPUT_PATH = "docs"
 VERSION_FILE_PATH = "snippet/_version.py"
 CHANGELOG_FILE_PATH = "CHANGELOG.md"
 
+[ProjectConfig.PACKAGES_WITH_CHECKED_LICENCE]
+python-dotenv = "BSD-3-Clause"
+
 [AutoVersionConfig]
 CONFIG_NAME = "DEFAULT"
 PRERELEASE_TOKEN = "beta"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     name=PROJECT_SLUG,
     packages=[SOURCE_DIR],
     python_requires=">=3.6,<4",
-    url=f"https://github.com/ARMmbed/snippet",
+    url="https://github.com/ARMmbed/snippet",
     version=__version__,
     entry_points=dict(
         console_scripts=[

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Documentation",
         "Topic :: Software Development :: Documentation",

--- a/snippet/api.py
+++ b/snippet/api.py
@@ -18,4 +18,4 @@ def extract_code_snippets(config: config.Config) -> None:
         LOGGER.error(
             "failures:\n%s", textwrap.indent("\n".join(f"{name}: {exc}" for name, exc in failures), prefix="  ")
         )
-        raise Exception(f"There were %s failures!" % len(failures))
+        raise Exception(f"There were {len(failures)} failures!")


### PR DESCRIPTION
### Description
Performs few changes:
CI changes to now test on Python 3.8 and generate a 3rd party IP report

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
